### PR TITLE
Adding subteam to have hyphen for IAM tag rules

### DIFF
--- a/sleuth/services.py
+++ b/sleuth/services.py
@@ -69,8 +69,9 @@ def format_slack_id(slackid):
         LOGGER.warning('Slack ID is None, which it should not be')
         return ''
 
-    if 'subteam' in slackid:
-        return '<!subteam^{}>'.format(slackid)
+    if 'subteam' in slackid and '-' in slackid:
+        # format and replace "-" with "^" since IAM rules doesn't allow "^"
+        return '<!{}>'.format(slackid).replace('-', '^')
     elif slackid[0] == 'U':
         return '<@{}>'.format(slackid)
     else:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -27,4 +27,10 @@ class TestFormatSlackID():
 
     def test_team_id(self):
         """Test a simple team id as input"""
-        pass
+        resp = format_slack_id('subteam-T12345')
+        assert resp == '<!subteam^T12345>'
+
+    def test_team_id_missing_hyphen(self):
+        """Test a team id missing a '-' as input"""
+        resp = format_slack_id('subteamT12345')
+        assert resp == 'subteamT12345'


### PR DESCRIPTION
IAM tag rules do not allow the "^" so when storing ID will store with "-", subteam-12345 and the tool will replace '-' to '^' when posting to slack.