### PR TITLE
New Dpeloyment Method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,5 +58,5 @@ workflows:
   version: 2
   validate:
     jobs:
-      - terratest
+      #- terratest
       - python-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,6 @@ workflows:
   version: 2
   validate:
     jobs:
-      #- terratest
+      - terratest
       - python-test
       - python-package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
             - "~/go/pkg/mod"
       - store_test_results:
           path: /tmp/test-results/gotest
+
   python-test:
     executor: python/default
     steps:
@@ -54,9 +55,27 @@ jobs:
       - python/test:
           pytest: true
 
+  python-package:
+    executor: python/default
+    steps:
+      - checkout
+      - run:
+          name: "Build deployment zip file"
+          command: |
+             pip install --target ./reqs -r sleuth/requirements.txt
+             cd reqs
+             zip -r9 ../deployment.zip .
+             cd ../sleuth
+             zip -r9 ../deployment.zip handler.py
+             zip -r9 ../deployment.zip -r sleuth/
+      - store_artifacts:
+          path: deployment.zip
+
+
 workflows:
   version: 2
   validate:
     jobs:
       #- terratest
       - python-test
+      - python-package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,4 +78,6 @@ workflows:
     jobs:
       - terratest
       - python-test
-      - python-package
+      - python-package:
+          - requires: python-test
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,5 +79,6 @@ workflows:
       - terratest
       - python-test
       - python-package:
-          - requires: python-test
+          requires:
+            - python-test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [1.0.5] - 2020-05-19
 
 ### Added
 
 - Serveral git precommits (markdown, terraform, terraformd-docs etc)
+
+
+### Changed
+
+- Deployment now uses pre-built zip file for lambda
+
+
+### Removed
+
+- Dropped custom packaging setup (very fragile)
 
 ## [0.9.0] - 2020-03-28
 


### PR DESCRIPTION
The old way of deploying was fragile. Example: it broke entirely on Atlantis due to some false assumptions about the environment.

So where does that leave us? After working through each of these one by one and running into roadblocks checking in the package into the repo was the only solution that worked as advertised.

## Serverless/Apex/AWS SAM
These are serverless tools/frameworks to help with everything from development to deployment. Unfortunately they aren't lightweight tools and have a lot of moving pieces. These leverage AWS CloudFormation for the deployment after handling the packaging to s3. In addition the deployment is entirely outside of TF which is another process to handle for updating such a tiny single lambda.

## Github Releases
This was a very attractive option as CircleCI can build a deployment package and publicly host it. This removes the packaging and local hosting issue as we can fetch the deployment package and push to lambda. The issue is all assets of a release are served as a `application/octet-stream` which the current TF [http data source](https://www.terraform.io/docs/providers/http/data_source.html) only accepts text and `application/json` format due to storing payloads in the TF state and possible corrupting them.

Attempts to shoehorn the deployment as a json to work with the http data source failed due to how GH serves the assets.

## Storing in S3 Private Bucket
This is the recommended way to push code to lambda. Store the payload in an s3 bucket and point the lambda to use that as a resource. This addresses a lot of issues including the 10mb max deployment payload AWS Lambda API limits. There are two issues with this. 

The first is now an S3 bucket is required that needs to be maintained and audited and all that good stuff. The second issue is deployments aren't a `terraform apply` away. There is a manual process where one has to upload the new deployment package to s3, update TF to point to new package to keep version keeping sane, and then apply to get the update. This really stinks for a 100 line utility lambda, but a solid and maybe only choice for large lambdas bundle with big libraries.

### Storing in S3 Public Bucket
This solves the majority of issues in Storing in a private S3 bucket. This would allow circleci to push deployments to s3 and the repo can point to the hosted location. This option has the issue of deployment is tied to who ever hosts the S3 bucket which other users may not like to depend on. The other issue is the S3 owner has a cost liability. This cost may be a few dollars a month but if usage grows or someone with bad intentions could run up the AWS bill which the S3 bucket owner would be responsible for.

## Using a `null_resource` to curl the asset
At first glance this looks like an easy solution. Lets have TF depend on a [null_resource](https://www.terraform.io/docs/providers/null/resource.html) and curl the file. The warts of this solution crops if anything happens to that file that doesn't agree with the state. `rm` the deployment file and watch TF work itself into a corner where you are blocked from apply or destroy. 

## Having TF zip the source via `archive_file`
This solves a lot of issues such as getting the source and packaging without any external deps on tooling such as `curl`. Just point the `archive_file` to the lambda source and let TF handle it. The problem is this works so far as the python source uses only [the libraries AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) support. Say you need an external lib like Slack API, now you have a packing issues to deal with.

## Check package in repo
Instead of relying on having the deployment package on an external resource add it to the repo. This takes care of the issue of obtaining the package, making sure it is versioned, and always available, and no packaging process (platform independent). Sadly this has a huge anti pattern of checking in artifacts into version control bloating the repo size.


## Future Work
For tiny lambdas like this the best option would be to have a new data source that would allow downloading of zip files and fully manage their lifecycle properly. There is a [PR](https://github.com/hashicorp/terraform-provider-http/pull/16) to allow the http data source to download other items than just JSON and forking that might be a solid solution to fetch deployment packages for small lambdas.