### PR TITLE
Expire inactive accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sleuth runs periodically, normally once a day in the middle of business hours. S
 
 - Inspect each Access Key based on:
   - set creation age threshold (default 90 days)
-  - set last accessed age threshold (default 30 days)
+  - set last accessed age threshold (optional, set to creation age threshold as default)
 - If Access Key is approaching threshold will ping user with a reminder to cycle key
 - If key age is at or over threshold will disable Access Key along with a final notice
 
@@ -106,7 +106,7 @@ The behavior can be configured by environment variables.
 | ENABLE_AUTO_EXPIRE | Must be set to `true` for key disable action |
 | EXPIRATION_AGE | Age of key creation (in days) to disable a AWS key |
 | WARNING_AGE | Age of key creation (in days) to send notifications, must be lower than EXPIRATION_AGE |
-| LAST_USED_AGE | Age of last key usage (in days) to send notifications, must be lower than or equal to EXPIRATION_AGE |
+| LAST_USED_AGE | OPTIONAL, defaults to EXPIRATION_AGE, Age of last key usage (in days) to send notifications, must be lower than or equal to EXPIRATION_AGE |
 | MSG_TITLE | Title of the notification message |
 | MSG_TEXT | Instructions on key rotation |
 | SLACK_URL | Incoming webhook to send notifications to |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ An auditing tool for AWS keys that audits, alerts, and disable keys if not withi
 
 Sleuth runs periodically, normally once a day in the middle of business hours. Sleuth does the following:
 
-- Inspect each Access Key based on set age threshold (default 90 days)
+- Inspect each Access Key based on:
+  - set creation age threshold (default 90 days)
+  - set last accessed age threshold (default 30 days)
 - If Access Key is approaching threshold will ping user with a reminder to cycle key
 - If key age is at or over threshold will disable Access Key along with a final notice
 
@@ -81,6 +83,7 @@ module "iam_sleuth" {
     ENABLE_AUTO_EXPIRE  = "false"
     EXPIRATION_AGE      = 90
     WARNING_AGE         = 50
+    LAST_USED_AGE       = 30
     SLACK_URL           = data.aws_ssm_parameter.slack_url.value
     SNS_TOPIC           = ""
     MSG_TITLE           = "Key Rotation Instructions"
@@ -101,8 +104,8 @@ The behavior can be configured by environment variables.
 | Name | Description |
 |------|------------ |
 | ENABLE_AUTO_EXPIRE | Must be set to `true` for key disable action |
-| EXPIRATION_AGE | Age in days to disable a AWS key |
-| WARNING_AGE | Age in days of key to send notifications, must be lower than EXPIRATION_AGE |
+| EXPIRATION_AGE | Age of key creation (in days) to disable a AWS key |
+| WARNING_AGE | Age of key creation (in days) to send notifications, must be lower than EXPIRATION_AGE |
 | MSG_TITLE | Title of the notification message |
 | MSG_TEXT | Instructions on key rotation |
 | SLACK_URL | Incoming webhook to send notifications to |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The behavior can be configured by environment variables.
 | ENABLE_AUTO_EXPIRE | Must be set to `true` for key disable action |
 | EXPIRATION_AGE | Age of key creation (in days) to disable a AWS key |
 | WARNING_AGE | Age of key creation (in days) to send notifications, must be lower than EXPIRATION_AGE |
+| LAST_USED_AGE | Age of last key usage (in days) to send notifications, must be lower than or equal to EXPIRATION_AGE |
 | MSG_TITLE | Title of the notification message |
 | MSG_TEXT | Instructions on key rotation |
 | SLACK_URL | Incoming webhook to send notifications to |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -29,6 +29,7 @@ module "iam_sleuth" {
     ENABLE_AUTO_EXPIRE  = false
     EXPIRATION_AGE      = 90
     WARNING_AGE         = 85
+    LAST_USED_AGE       = 30
     MSG_TITLE           = "Key Rotation Instructions"
     MSG_TEXT            = "Please run key rotation tool!"
   }

--- a/sleuth/sleuth/auditor.py
+++ b/sleuth/sleuth/auditor.py
@@ -52,7 +52,7 @@ class Key():
         assert(max_last_used_age <= expire_age)
 
         # set the valid_for in the object
-        self.valid_for = min(expire_age - self.creation_age, max_last_used_age)
+        self.valid_for = expire_age - self.creation_age
 
         # lets audit the age
         if self.creation_age >= expire_age:

--- a/sleuth/sleuth/services.py
+++ b/sleuth/sleuth/services.py
@@ -25,6 +25,7 @@ def get_iam_key_info(user):
     list (Key): Return list of keys for a single user
     """
     from sleuth.auditor import Key
+    keys = []
     key_info = IAM.list_access_keys(UserName=user.username)
     for k in key_info['AccessKeyMetadata']:
         access_date=IAM.get_access_key_last_used(AccessKeyId=k['AccessKeyId'])

--- a/sleuth/sleuth/services.py
+++ b/sleuth/sleuth/services.py
@@ -25,13 +25,15 @@ def get_iam_key_info(user):
     list (Key): Return list of keys for a single user
     """
     from sleuth.auditor import Key
-    resp = IAM.list_access_keys(UserName=user.username)
-    keys = []
-    for k in resp['AccessKeyMetadata']:
+    key_info = IAM.list_access_keys(UserName=user.username)
+    for k in key_info['AccessKeyMetadata']:
+        access_date=IAM.get_access_key_last_used(AccessKeyId=k['AccessKeyId'])
         keys.append(Key(k['UserName'],
                         k['AccessKeyId'],
                         k['Status'],
-                        k['CreateDate']))
+                        k['CreateDate'],
+                        access_date['AccessKeyLastUsed']['LastUsedDate'] if 'LastUsedDate' in access_date['AccessKeyLastUsed'] else k['CreateDate']))
+
     return keys
 
 

--- a/sleuth/tests/test_auditor.py
+++ b/sleuth/tests/test_auditor.py
@@ -5,59 +5,69 @@ import pytest
 
 from sleuth.auditor import Key
 
-
 @freeze_time("2019-01-16")
 class TestKey():
     def test_normal(self):
         """Normal happy path, key is good"""
         created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
-        k = Key('username', 'keyid', 'Active', created)
-        k.audit(60, 80)
-
-        assert k.age == 15
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        k = Key('username', 'keyid', 'Active', created, last_used)
+        k.audit(60, 80, 20)
+        assert k.creation_age == 15
         assert k.audit_state == 'good'
 
     def test_rotate(self):
         """Key is past rotate age, key is marked as old"""
         created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
-        k = Key('username', 'keyid', 'Active', created)
-        k.audit(10, 80)
-
-        assert k.audit_state == 'old'
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        key = Key('username', 'keyid', 'Active', created, last_used)
+        key.audit(10, 80, 20)
+        assert key.audit_state == 'old'
 
     def test_old(self):
         """Key is past max threshold, key is marked as expired"""
         created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
-        k = Key('username', 'keyid', 'Active', created)
-        k.audit(10, 11)
-
-        assert k.audit_state == 'expire'
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        key = Key('username', 'keyid', 'Active', created, last_used)
+        key.audit(10, 11, 10)
+        assert key.audit_state == 'expire'
 
     def test_no_disable(self, monkeypatch):
         """Key is disabled AWS status of Inactive, but disabling is turned off so key remains audit state expire"""
         monkeypatch.setenv('ENABLE_AUTO_EXPIRE', 'false')
         created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
-        k = Key('username', 'keyid', 'Inactive', created)
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        key = Key('user2', 'ldasfkk', 'Inactive', created, last_used)
+        key.audit(10, 11, 10)
+        assert key.audit_state == 'expire'
 
-        k.audit(10, 11)
-        assert k.audit_state == 'expire'
+    def test_last_used(self, monkeypatch):
+        """Key has not been used in X days, key marked is disabled"""
+        monkeypatch.setenv('ENABLE_AUTO_EXPIRE', 'true')
+        monkeypatch.setenv('LAST_USED_AGE', '10')
+        created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        key = Key('user3', 'kljin', 'Active', created, last_used)
+        key.audit(10, 11, 1)
+        assert key.audit_state == 'expire'
+        key.audit(60, 80, 1)
+        assert key.audit_state == 'expire'
 
-    def test_inactive(self, monkeypatch):
+    def test_disabled(self, monkeypatch):
         """Key is disabled AWS status of Inactive, key marked is disabled"""
         monkeypatch.setenv('ENABLE_AUTO_EXPIRE', 'true')
         created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
-        k = Key('username', 'keyid', 'Inactive', created)
-
-        k.audit(10, 11)
-        assert k.audit_state == 'disabled'
-        k.audit(60, 80)
-        assert k.audit_state == 'disabled'
-
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        key = Key('user2', 'ldasfkk', 'Inactive', created, last_used)
+        key.audit(10, 11, 10)
+        assert key.audit_state == 'disabled'
+        key.audit(60, 80, 30)
+        assert key.audit_state == 'disabled'
 
     def test_invalid(self):
         """Key is disabled AWS status of Inactive, key marked is disabled"""
         created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
-        k = Key('username', 'keyid', 'Inactive', created)
-
+        last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
+        key = Key('user2', 'ldasfkk', 'Inactive', created, last_used)
         with pytest.raises(AssertionError):
-            k.audit(5, 1)
+            key.audit(5, 1, 1)

--- a/sleuth/tests/test_services.py
+++ b/sleuth/tests/test_services.py
@@ -7,11 +7,12 @@ from sleuth.services import format_slack_id, prepare_sns_message, prepare_slack_
 from sleuth.auditor import Key, User
 
 created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
+lastused = created = datetime.datetime(2019, 1, 3, tzinfo=datetime.timezone.utc)
 user1 = User('user1', 'slackuser1', 'U12345')
 user2 = User('user1', 'slackuser1', 'U67890')
-key1 = Key('user1', 'asdfksakfa', 'Active', created)
+key1 = Key('user1', 'asdfksakfa', 'Active', created, lastused)
 key1.audit_state = 'old'
-key2 = Key('user2', 'ldasfkk', 'Active', created)
+key2 = Key('user2', 'ldasfkk', 'Active', created, lastused)
 key2.audit_state = 'expire'
 user1.keys = [key1]
 user2.keys = [key2]


### PR DESCRIPTION
[Add env variable to expire inactive accounts](https://www.pivotaltracker.com/story/show/176467785)

Code changes:
- Add env variable (LAST_USED_AGE) to expire keys that have not been accessed in X days
- Update classes to incorporate new variable or use a default
- Update logic to include to variable in deciding to expire key 
- Update and add tests to incorporate new variable 

