### PR TITLE
Correctly Purge CW Log during tf destroy

### DIFF
--- a/test/terraform_aws_sleuth_simple_test.go
+++ b/test/terraform_aws_sleuth_simple_test.go
@@ -48,6 +48,10 @@ func TestTerraformSimpleSanityCheck(t *testing.T) {
 	// lets try to invoke the lambda to ensure proper setup
 	_, err := aws.InvokeFunctionE(t, awsRegion, "iam-sleuth-test", FunctionPayload{ShouldFail: false, Echo: "hi!"})
 
+	// Sleep here to let all the lambda logs in flight write to log group.
+	// Failing to sleep here will recreate the log group after tf destroy
+	time.Sleep(60 * time.Second)
+
 	// Function-specific errors have their own special return, should be nil
 	functionError, ok := err.(*aws.FunctionError)
 	require.False(t, ok)


### PR DESCRIPTION
This PR is to fix the issue of persisting CW Log Group which causes issues during subsequent runs.

```
--- FAIL: TestTerraformSimpleSanityCheck (27.29s)
    apply.go:15:
                Error Trace:    apply.go:15
                                                        terraform_aws_sleuth_simple_test.go:43
                Error:          Received unexpected error:
                                FatalError{Underlying: error while running command: exit status 1;
                                Error: Creating CloudWatch Log Group failed: ResourceAlreadyExistsException: The specified log group already exists:  The CloudWatch Log Group '/aws/lambda/iam-sleuth-test' already exists.

                                }
                Test:           TestTerraformSimpleSanityCheck

```

The fix implemented is to ensure that all in flight log messages are written to the log group before letting terraform destroy run.