### PR TITLE
update circleci python orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@0.3.2
+  python: circleci/python@1.3.2
 
 jobs:
   build:
@@ -52,17 +52,13 @@ jobs:
     executor: python/default
     steps:
       - checkout
-      - python/load-cache:
-          dependency-file: ./sleuth/requirements.txt
-          # The scheme here let's us bust the cache if python is upgraded or if we modify the requirements
-          key: pip-3.8.5-{{ checksum "./sleuth/requirements.txt" }}
-      - python/install-deps:
-          dependency-file: ./sleuth/requirements.txt
-      - python/save-cache:
-          dependency-file: ./sleuth/requirements.txt
-          key: pip-3.8.5-{{ checksum "./sleuth/requirements.txt" }}
-      - python/test:
-          pytest: true
+      - python/install-packages:
+          pip-dependency-file: ./sleuth/requirements.txt
+          pkg-manager: pip
+          include-python-in-cache-key: true
+      - run:
+          command: |
+            pytest
   terratest:
     docker:
     - auth:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Sleuth runs periodically, normally once a day in the middle of business hours. S
   - set last accessed age threshold (optional, set to creation age threshold as default)
 - If Access Key is approaching threshold will ping user with a reminder to cycle key
 - If key age is at or over threshold will disable Access Key along with a final notice
+- If user has special KeyAutoExpire tag set to False, the key will not be auto-expired
 
 Notifications can be sent directly to Slack using a V1 token or through SNS Topic.
 

--- a/sleuth/sleuth/auditor.py
+++ b/sleuth/sleuth/auditor.py
@@ -103,12 +103,13 @@ def print_key_report(users):
                 u.username,
                 u.slack_id,
                 k.key_id,
+                u.auto_expire,
                 k.audit_state,
                 k.creation_age,
                 k.access_age
             ])
 
-    print(tabulate(tbl_data, headers=['UserName', 'Slack ID', 'Key ID', 'Status', 'Age in Days', 'Last Access Age']))
+    print(tabulate(tbl_data, headers=['UserName', 'Slack ID', 'Key ID', 'AutoExpire', 'Status', 'Age in Days', 'Last Access Age']))
 
 
 def audit():
@@ -117,7 +118,7 @@ def audit():
     # lets audit keys so the ages and state are set
     for u in iam_users:
         # Do not audit keys that are set to not allow auto-expire
-        if u.auto_expire=='False':
+        if u.auto_expire.lower()=='false':
             LOGGER.info('{} key is set to not expire'.format(u.username))
             for k in u.keys:
                 k.audit_state='good'

--- a/sleuth/sleuth/services.py
+++ b/sleuth/sleuth/services.py
@@ -111,7 +111,9 @@ def get_iam_users():
                 LOGGER.info('IAM User: {} is missing Slack tag!'.format(u['UserName']))
                 # since no slack id, lets fill in the username so at least we know the account
                 tags['Slack'] = u['UserName']
-            user = User(u['UserId'], u['UserName'], tags['Slack'])
+            if 'KeyAutoExpire' not in tags:
+                tags['KeyAutoExpire'] = True
+            user = User(u['UserId'], u['UserName'], tags['Slack'], tags['KeyAutoExpire'])
             user.keys = get_iam_key_info(user)
             users.append(user)
 

--- a/sleuth/sleuth/services.py
+++ b/sleuth/sleuth/services.py
@@ -112,7 +112,7 @@ def get_iam_users():
                 # since no slack id, lets fill in the username so at least we know the account
                 tags['Slack'] = u['UserName']
             if 'KeyAutoExpire' not in tags:
-                tags['KeyAutoExpire'] = True
+                tags['KeyAutoExpire'] = 'True'
             user = User(u['UserId'], u['UserName'], tags['Slack'], tags['KeyAutoExpire'])
             user.keys = get_iam_key_info(user)
             users.append(user)


### PR DESCRIPTION
The issue:
Pytest was failing due to python version 3.8.7 not found in circle ci env. CircleCI updated the python version in their python orb to 3.8.8, but our config was using a pip cache that was incompatible. 

The fix:
Update the circle ci python orb version from 0.3.2 to 1.3.2, which now uses the checksum of the pyenv python version as the cache-key. 

