### PR TITLE
update circleci python orb to 1.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@0.3.2
+  python: circleci/python@1.3.2
 
 jobs:
   build:
@@ -52,17 +52,13 @@ jobs:
     executor: python/default
     steps:
       - checkout
-      - python/load-cache:
-          dependency-file: ./sleuth/requirements.txt
-          # The scheme here let's us bust the cache if python is upgraded or if we modify the requirements
-          key: pip-3.8.5-{{ checksum "./sleuth/requirements.txt" }}
-      - python/install-deps:
-          dependency-file: ./sleuth/requirements.txt
-      - python/save-cache:
-          dependency-file: ./sleuth/requirements.txt
-          key: pip-3.8.5-{{ checksum "./sleuth/requirements.txt" }}
-      - python/test:
-          pytest: true
+      - python/install-packages:
+          pip-dependency-file: ./sleuth/requirements.txt
+          pkg-manager: pip
+          include-python-in-cache-key: true
+      - run:
+          command: |
+            pytest
   terratest:
     docker:
     - auth:


### PR DESCRIPTION
The issue:
Pytest was failing due to python version 3.8.7 not found in circle ci env. CircleCI updated the python version in their python orb to 3.8.8, but our config was using a pip cache that was incompatible.

The fix:
Update the circle ci python orb version from 0.3.2 to 1.3.2, which now uses the checksum of the pyenv python version as the cache-key.