### PR TITLE
Ee run terratest on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,15 @@ jobs:
       - run:
           name: Release
           command: scripts/release $CIRCLE_PROJECT_USERNAME $CIRCLE_PROJECT_REPONAME << pipeline.git.tag >>
+      - run:
+          name: Move checksum to workspace
+          command: |
+            mkdir -p workspace
+            cp checksum.txt workspace/checksum.txt
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - checksum.txt
   validate:
     docker:
       - image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
@@ -71,6 +80,8 @@ jobs:
         keys:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
         - go-mod-sources-v1-{{ checksum "go.sum" }}
+    - attach_workspace:
+        at: /tmp/workspace
     - run:
         command: |
           temp_role=$(aws sts assume-role --role-arn arn:aws:iam::313564602749:role/circleci --role-session-name circleci)
@@ -78,7 +89,7 @@ jobs:
           export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
           export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
           export RELEASE_TAG=<< pipeline.git.tag >>
-          export VALIDATION_SHA=$(cut -f1 -d' ' checksums.txt)
+          export VALIDATION_SHA=$(cut -f1 -d' ' /tmp/workspace/checksums.txt)
           make test
         name: Assume role, run pre-commit and run terratest
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ jobs:
           name: Move checksum to workspace
           command: |
             mkdir -p workspace
-            cp checksum.txt workspace/checksum.txt
+            cp checksums.txt workspace/checksums.txt
       - persist_to_workspace:
           root: workspace
           paths:
-            - checksum.txt
+            - checksums.txt
   validate:
     docker:
       - image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,5 @@ workflows:
       - terratest:
           context:
           - org-global
-          filters:
-            branches:
-              ignore: /^.*/
-            tags:
-              only: /^v.*/
+          requires:
+            - release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,13 +98,18 @@ workflows:
       - python-test:
           context:
           - org-global
-      - terratest:
-          context:
-          - org-global
 
   release:
     jobs:
       - release:
+          context:
+          - org-global
+          filters:
+            branches:
+              ignore: /^.*/
+            tags:
+              only: /^v.*/
+      - terratest:
           context:
           - org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,5 +114,10 @@ workflows:
       - terratest:
           context:
           - org-global
+          filters:
+            branches:
+              ignore: /^.*/
+            tags:
+              only: /^v.*/
           requires:
             - release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,8 @@ jobs:
           export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
           export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
           export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+          export RELEASE_TAG=<< pipeline.git.tag >>
+          export VALIDATION_SHA=$(cut -f1 -d' ' checksums.txt)
           make test
         name: Assume role, run pre-commit and run terratest
     - save_cache:

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -17,9 +17,9 @@ module "iam_sleuth" {
 
   github_project  = "trussworks/aws-iam-sleuth"
   github_filename = "deployment.zip"
-  github_release  = "v1.2.1"
+  github_release  = var.github_release
 
-  validation_sha = "e828dc6992c986091631de26f2fca5ea700d375b25e4482b8db7366028445852"
+  validation_sha = var.validation_sha
 
   source_types = ["events"]
   source_arns  = [aws_cloudwatch_event_rule.lambda_rule_trigger.arn]

--- a/examples/simple/varables.tf
+++ b/examples/simple/varables.tf
@@ -1,0 +1,7 @@
+variable "github_release" {
+  type = string
+}
+
+variable "validation_sha" {
+  type = string
+}

--- a/test/terraform_aws_sleuth_simple_test.go
+++ b/test/terraform_aws_sleuth_simple_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -30,9 +31,15 @@ func TestTerraformSimpleSanityCheck(t *testing.T) {
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
 	awsRegion := "us-east-2"
 
+	github_release := os.Getenv("RELEASE_TAG")    //"v1.2.1"
+	validation_sha := os.Getenv("VALIDATION_SHA") //"2c307bab9f2e055dd4ac10cce78413598ac07a3c8739e540c3e396cef8905077"
+
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
-		Vars:         map[string]interface{}{},
+		Vars: map[string]interface{}{
+			"github_release": github_release,
+			"validation_sha": validation_sha,
+		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
 			"AWS_REGION":         awsRegion,

--- a/test/terraform_aws_sleuth_simple_test.go
+++ b/test/terraform_aws_sleuth_simple_test.go
@@ -31,8 +31,8 @@ func TestTerraformSimpleSanityCheck(t *testing.T) {
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
 	awsRegion := "us-east-2"
 
-	github_release := os.Getenv("RELEASE_TAG")    //"v1.2.1"
-	validation_sha := os.Getenv("VALIDATION_SHA") //"2c307bab9f2e055dd4ac10cce78413598ac07a3c8739e540c3e396cef8905077"
+	github_release := os.Getenv("RELEASE_TAG")
+	validation_sha := os.Getenv("VALIDATION_SHA")
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,


### PR DESCRIPTION
Because the simple example that terratest uses requires the validation sha and the release version strings to run this makes more sense to validate after a release that this is compatible with terraform.

This PR moves the Terratest circleci job into the release workflow. The terratest job now exports the release tag and the validation sha to environment variables that terratest will pick up.

This should solve the weird thing we've been doing with releases where we run the release then have to do an additional commit to update the terratest example.