### PR TITLE
[MB-7353] better slack messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2021-03-30
+
+### Added
+
+- New variables for INACTIVE_NOTIFICATION_TITLE and INACTIVE_NOTIFICATION_TEXT
+- Improved messaging for key expiration reasonings
+- Documentation for testing app locally
+- Required permission for iam:GetAccessKeyLastUsed
+
 ## [1.2.1] - 2021-03-04
 
 ### Added

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -58,6 +58,7 @@ data "aws_iam_policy_document" "basic_task_role_policy_doc" {
       "iam:UpdateAccessKey",
       "iam:ListAccessKeys",
       "iam:ListUserTags",
+      "iam:GetAccessKeyLastUsed",
     ]
 
     resources = ["arn:aws:iam::*:user/*"]

--- a/sleuth/handler.py
+++ b/sleuth/handler.py
@@ -36,7 +36,7 @@ LOGGER.addHandler(logHandler)
 
 from sleuth.auditor import audit
 
-VERSION = '1.2.1'
+VERSION = '1.3.0'
 
 def handler(event, context):
     """

--- a/sleuth/sleuth/auditor.py
+++ b/sleuth/sleuth/auditor.py
@@ -124,7 +124,7 @@ def print_key_report(users):
 
 def audit():
     iam_users = get_iam_users()
-    print(iam_users)
+
     # Check for optional env vars
     if (os.environ.get('INACTIVITY_AGE') and not os.environ.get('INACTIVITY_WARNING_AGE')) or (os.environ.get('INACTIVITY_WARNING_AGE') and not os.environ.get('INACTIVITY_AGE')):
         raise RuntimeError('Must set env var INACTIVITY_WARNING_AGE and INACTIVITY_AGE together')

--- a/sleuth/sleuth/auditor.py
+++ b/sleuth/sleuth/auditor.py
@@ -21,7 +21,8 @@ class Key():
 
     creation_age = 0
     access_age = 0
-    valid_for = 0
+    creation_valid_for = 0
+    activity_valid_for = 0
 
     def __init__(self, username, key_id, status, created, inactivity_age):
         self.username = username
@@ -44,7 +45,7 @@ class Key():
         rotate (int): Age key must be before audit_state=old
         expire (int): Age key must be before audit_state=expire
         inactivity_age (int): Age of last key usage must be before audit_state=expire
-        inactivity_warning_age (int): Age of last key usage must be before audit_state=old
+        inactivity_warning_age (int): Age of last key usage must be before audit_state=stagnant
 
         Returns:
         None
@@ -54,16 +55,22 @@ class Key():
         assert(inactivity_warning_age < max_inactivity_age)
 
         # set the valid_for in the object
-        self.valid_for = expire_age - self.creation_age
+        self.creation_valid_for = expire_age - self.creation_age
+        self.activity_valid_for = max_inactivity_age - self.access_age
+
 
         # lets audit the age
         if self.creation_age >= expire_age:
             self.audit_state = 'expire'
         elif self.access_age >= max_inactivity_age:
-            self.audit_state = 'expire'
-        # audit key age and last used age
-        elif (self.creation_age >= rotate_age and self.creation_age < expire_age) or (self.access_age >= inactivity_warning_age and self.access_age < max_inactivity_age):
+            self.audit_state = 'stagnant_expire'
+        # audit key age, which is more important than inactivity age
+        elif (self.creation_age >= rotate_age and self.creation_age < expire_age):
             self.audit_state = 'old'
+        # audit activity age, set to 'stagnant' to not confuse with AWS official "Inactive" status
+        elif (self.access_age >= inactivity_warning_age and self.access_age < max_inactivity_age):
+            self.audit_state = 'stagnant'
+        # finally, if nothing requires us to alert on this key, set to good
         elif self.creation_age < rotate_age:
             self.audit_state = 'good'
 
@@ -117,10 +124,10 @@ def print_key_report(users):
 
 def audit():
     iam_users = get_iam_users()
-
+    print(iam_users)
     # Check for optional env vars
     if (os.environ.get('INACTIVITY_AGE') and not os.environ.get('INACTIVITY_WARNING_AGE')) or (os.environ.get('INACTIVITY_WARNING_AGE') and not os.environ.get('INACTIVITY_AGE')):
-        raise RuntimeError('Must set env var INACTIVITY_WARNING_AGE and INACTIVITY_AGE')
+        raise RuntimeError('Must set env var INACTIVITY_WARNING_AGE and INACTIVITY_AGE together')
 
     # lets audit keys so the ages and state are set
     for u in iam_users:
@@ -140,18 +147,21 @@ def audit():
     if os.environ.get('ENABLE_AUTO_EXPIRE', False) == 'true':
         for u in iam_users:
             for k in u.keys:
-                if k.audit_state == 'expire':
+                if k.audit_state == 'expire' or k.audit_state == 'stagnant_expire':
                     disable_key(k, u.username)
     else:
         LOGGER.warn('Cannot disable AWS Keys, ENABLE_AUTO_EXPIRE set to False')
 
-    MSG_TITLE = os.environ.get('NOTIFICATION_TITLE', 'AWS IAM Key Report')
-    MSG_TEXT = os.environ.get('NOTIFICATION_TEXT', '')
+    # Default expiration headers
+    EXP_MSG_TITLE = os.environ.get('EXPIRE_NOTIFICATION_TITLE', 'AWS IAM Key Expiration Report')
+    EXP_MSG_TEXT = os.environ.get('EXPIRE_NOTIFICATION_TEXT', '')
+    STGNT_MSG_TITLE = os.environ.get('INACTIVE_NOTIFICATION_TITLE', 'AWS IAM Key Inactivity Report')
+    STGNT_MSG_TEXT = os.environ.get('INACTIVE_NOTIFICATION_TEXT', '')
 
     # lets assemble the SNS message
     if os.environ.get('SNS_TOPIC', None) is not None:
         LOGGER.info('Detected SNS settings, preparing and sending message via SNS')
-        send_to_slack, slack_msg = prepare_sns_message(iam_users, MSG_TITLE, MSG_TEXT)
+        send_to_slack, slack_msg = prepare_sns_message(iam_users, EXP_MSG_TITLE, EXP_MSG_TEXT, STGNT_MSG_TITLE, STGNT_MSG_TEXT)
 
         if send_to_slack:
             send_sns_message(os.environ['SNS_TOPIC'], slack_msg)
@@ -163,9 +173,10 @@ def audit():
     if os.environ.get('SLACK_URL', None) is not None:
         LOGGER.info('Detected Slack settings, preparing and sending message via Slack API')
         # lets assemble the slack message
-        send_to_slack, slack_msg = prepare_slack_message(iam_users, MSG_TITLE, MSG_TEXT)
-
-        if send_to_slack:
+        send_to_slack, slack_msg = prepare_slack_message(iam_users, EXP_MSG_TITLE, EXP_MSG_TEXT, STGNT_MSG_TITLE, STGNT_MSG_TEXT)
+        if os.environ.get('DEBUG', False):
+            print("slack message:", slack_msg)
+        elif send_to_slack:
             send_slack_message(os.environ['SLACK_URL'], slack_msg)
         else:
             LOGGER.info('Nothing to report')

--- a/sleuth/tests/test_auditor.py
+++ b/sleuth/tests/test_auditor.py
@@ -30,7 +30,7 @@ class TestKey():
         last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
         key = Key('username', 'keyid', 'Active', created, last_used)
         key.audit(60, 80, 20, 10)
-        assert key.audit_state == 'old'
+        assert key.audit_state == 'stagnant'
 
     def test_old_expiration(self):
         """Key is past max expiration threshold, key is marked as expired"""
@@ -46,7 +46,7 @@ class TestKey():
         last_used = datetime.datetime(2019, 1, 2, tzinfo=datetime.timezone.utc)
         key = Key('username', 'keyid', 'Active', created, last_used)
         key.audit(60, 80, 10, 9)
-        assert key.audit_state == 'expire'
+        assert key.audit_state == 'stagnant_expire'
 
     def test_no_disable(self, monkeypatch):
         """Key is disabled AWS status of Inactive, but disabling is turned off so key remains audit state expire"""
@@ -67,7 +67,7 @@ class TestKey():
         key.audit(10, 11, 2, 1)
         assert key.audit_state == 'expire'
         key.audit(60, 80, 2, 1)
-        assert key.audit_state == 'expire'
+        assert key.audit_state == 'stagnant_expire'
 
     def test_disabled(self, monkeypatch):
         """Key is disabled AWS status of Inactive, key marked is disabled"""

--- a/sleuth/tests/test_services.py
+++ b/sleuth/tests/test_services.py
@@ -8,15 +8,28 @@ from sleuth.auditor import Key, User
 
 created = datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc)
 lastused = created = datetime.datetime(2019, 1, 3, tzinfo=datetime.timezone.utc)
+# 4 users to represent the 4 audit states
 user1 = User('user1', 'slackuser1', 'U12345')
-user2 = User('user1', 'slackuser1', 'U67890')
 key1 = Key('user1', 'asdfksakfa', 'Active', created, lastused)
 key1.audit_state = 'old'
+
+user2 = User('user2', 'slackuser2', 'U67890')
 key2 = Key('user2', 'ldasfkk', 'Active', created, lastused)
 key2.audit_state = 'expire'
+
+user3 = User('user3', 'slackuser3', 'U13579')
+key3 = Key('user3', 'oithsetc', 'Active', created, lastused)
+key3.audit_state = 'stagnant'
+
+user4 = User('user4', 'slackuser4', 'U24680')
+key4 = Key('user4', 'bajaoietnb', 'Active', created, lastused)
+key4.audit_state = 'stagnant_expire'
+
 user1.keys = [key1]
 user2.keys = [key2]
-users = [user1, user2]
+user3.keys = [key3]
+user4.keys = [key4]
+users = [user1, user2, user3, user4]
 
 class TestFormatSlackID():
     def test_empty_input(self):
@@ -59,18 +72,39 @@ class TestFormatSlackID():
         title = 'This is the SNS message'
         addltext = 'boop boop'
 
-        send_to_sns, msg = prepare_sns_message(users, title, addltext)
+        t2 = 'INACTIVE WARNING'
+        tadd = 'Inactive instructions'
+
+        send_to_sns, msg = prepare_sns_message(users, title, addltext, t2, tadd)
         assert title in msg
         assert addltext in msg
+        assert t2 in msg
+        assert tadd in msg
 
     def test_slack_message_customization(self, monkeypatch):
         """Test that the slack message can be customized"""
         title = 'SLACK TITLE'
         addltext = 'Slack content'
 
-        send_to_slack, msg = prepare_slack_message(users, title, addltext)
+        t2 = 'INACTIVE WARNING'
+        tadd = 'Inactive instructions'
 
-        assert len(msg['attachments']) == 3
+        send_to_slack, msg = prepare_slack_message(users, title, addltext, t2, tadd)
+
+        assert len(msg['attachments']) == 6
         last_attachment = msg['attachments'][0]
         assert last_attachment['title'] == title
         assert last_attachment['text'] == addltext
+
+        # Test for the different message contexts
+        old="IAM users with access keys expiring due to creation age"
+        exp="IAM users with disabled access keys due to creation age"
+        stgn="IAM users with access keys expiring due to inactivity. \n Please login to AWS to prevent key from being disabled"
+        stgn_exp="IAM users with disabled access keys due to inactivity"
+        assert msg['attachments'][1]['title'] == old
+        assert msg['attachments'][2]['title'] == exp
+        assert msg['attachments'][3]['title'] == stgn_exp
+        assert msg['attachments'][4]['title'] == t2
+        assert msg['attachments'][4]['text'] == tadd
+        assert msg['attachments'][5]['title'] == stgn
+


### PR DESCRIPTION

[Update the slack messaging for clarity around key expiration reasons.](https://dp3.atlassian.net/browse/MB-7353)

Code changes:
- Add INACTIVE_NOTIFICATION_TITLE and INACTIVE_NOTIFICATION_TEXT to allow for separate instructions on using stagnant key to prevent auto-expiration
- Update tests for new variables
- Add additional DEBUG statements for including slack message outputs when in DEBUG mode
- Update README to include instructions for running app locally