### PR TITLE
ci: removing PR limit from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,6 @@
       ]
     }
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Removing PR limit from renovate to allow it to open as many PRs as it needs to.
